### PR TITLE
Fixed compile issue due to incorrect unicode space character

### DIFF
--- a/src/main/java/io/github/terra121/TerraConfig.java
+++ b/src/main/java/io/github/terra121/TerraConfig.java
@@ -50,7 +50,7 @@ public class TerraConfig {
 	public static boolean threeWater = false;
 
 	@SubscribeEvent
-	public static void onConfigChanged﻿(ConfigChangedEvent.OnConfigChangedEvent event) {
+	public static void onConfigChanged(ConfigChangedEvent.OnConfigChangedEvent event) {
 		if(TerraMod.MODID.equals(event.getModID()))
 			ConfigManager.sync(TerraMod.MODID, Config.Type.INSTANCE);
 	}


### PR DESCRIPTION
An unusual space character which was added in commit bbc1ffd73634e22a5beafc8c5de8b70a974d33b8 is causing graddle to whine about it and fail compilation on Windows.
Removing this character seems to fix the issue.