### PR TITLE
Better Buildings from OSM

### DIFF
--- a/src/main/java/io/github/terra121/EarthTerrainProcessor.java
+++ b/src/main/java/io/github/terra121/EarthTerrainProcessor.java
@@ -25,6 +25,7 @@ import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.CustomGenerato
 import io.github.opencubicchunks.cubicchunks.cubicgen.customcubic.structure.CubicCaveGenerator;
 import io.github.terra121.dataset.Heights;
 import io.github.terra121.dataset.OpenStreetMaps;
+import io.github.terra121.populator.BuildingGenerator;
 import io.github.terra121.populator.CliffReplacer;
 import io.github.terra121.populator.EarthTreePopulator;
 import io.github.terra121.populator.RoadGenerator;
@@ -82,6 +83,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
         
         surfacePopulators = new HashSet<ICubicPopulator>();
         if(doRoads || cfg.settings.osmwater)surfacePopulators.add(new RoadGenerator(osm, heights, projection));
+        if(doBuildings || cfg.settings.buildings)surfacePopulators.add(new BuildingGenerator(osm, heights, projection));
         surfacePopulators.add(new EarthTreePopulator(projection));
         snow = new SnowPopulator(); //this will go after the rest
 
@@ -289,7 +291,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
         /**
          * If event is not canceled we will use cube populators from registry.
          **/
-        if (!MinecraftForge.EVENT_BUS.post(new CubePopulatorEvent(world, cube))) {
+        //if (!MinecraftForge.EVENT_BUS.post(new CubePopulatorEvent(world, cube))) {
             Random rand = Coords.coordsSeedRandom(world.getSeed(), cube.getX(), cube.getY(), cube.getZ());
             
             Biome biome = cube.getBiome(Coords.getCubeCenter(cube));
@@ -316,7 +318,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
 
             MinecraftForge.EVENT_BUS.post(new PopulateCubeEvent.Post(world, rand, cube.getX(), cube.getY(), cube.getZ(), false));
             CubeGeneratorsRegistry.generateWorld(world, rand, pos, biome);
-        }
+        //}
     }
 
     //TODO: so inefficient but it's the best i could think of, short of caching this state by coords

--- a/src/main/java/io/github/terra121/EarthTerrainProcessor.java
+++ b/src/main/java/io/github/terra121/EarthTerrainProcessor.java
@@ -55,6 +55,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
     private CustomGeneratorSettings cubiccfg;
     private Set<ICubicPopulator> surfacePopulators;
     private Map<Biome, ICubicPopulator> biomePopulators;
+    private BuildingGenerator buildingGenerator;
     private CubicCaveGenerator caveGenerator;
     private SnowPopulator snow;
 	public EarthGeneratorSettings cfg;
@@ -83,7 +84,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
         
         surfacePopulators = new HashSet<ICubicPopulator>();
         if(doRoads || cfg.settings.osmwater)surfacePopulators.add(new RoadGenerator(osm, heights, projection));
-        if(doBuildings || cfg.settings.buildings)surfacePopulators.add(new BuildingGenerator(osm, heights, projection));
+        if(doBuildings || cfg.settings.buildings) buildingGenerator = new BuildingGenerator(osm, heights, projection);
         surfacePopulators.add(new EarthTreePopulator(projection));
         snow = new SnowPopulator(); //this will go after the rest
 
@@ -214,6 +215,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
         }
         
         caveGenerator.generate(world, primer, new CubePos(cubeX, cubeY, cubeZ));
+        buildingGenerator.generate(world, primer, new CubePos(cubeX, cubeY, cubeZ));
 
         //spawn roads
         if((doRoads || doBuildings || cfg.settings.osmwater) && surface) {
@@ -291,7 +293,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
         /**
          * If event is not canceled we will use cube populators from registry.
          **/
-        //if (!MinecraftForge.EVENT_BUS.post(new CubePopulatorEvent(world, cube))) {
+        if (!MinecraftForge.EVENT_BUS.post(new CubePopulatorEvent(world, cube))) {
             Random rand = Coords.coordsSeedRandom(world.getSeed(), cube.getX(), cube.getY(), cube.getZ());
             
             Biome biome = cube.getBiome(Coords.getCubeCenter(cube));
@@ -318,7 +320,7 @@ public class EarthTerrainProcessor extends BasicCubeGenerator {
 
             MinecraftForge.EVENT_BUS.post(new PopulateCubeEvent.Post(world, rand, cube.getX(), cube.getY(), cube.getZ(), false));
             CubeGeneratorsRegistry.generateWorld(world, rand, pos, biome);
-        //}
+        }
     }
 
     //TODO: so inefficient but it's the best i could think of, short of caching this state by coords

--- a/src/main/java/io/github/terra121/dataset/Building.java
+++ b/src/main/java/io/github/terra121/dataset/Building.java
@@ -1,0 +1,204 @@
+package io.github.terra121.dataset;
+
+import io.github.terra121.projection.GeographicProjection;
+import net.minecraft.block.BlockColored;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class Building {
+    public Polygon[] outerPolygons;
+    public Polygon[] innerPolygons;
+
+    public boolean hasCalculatedHeights = false;
+    public double heightOfLowestCorner;
+    public double heightOfHighestCorner;
+
+    public OpenStreetMaps.Element element;
+
+    public int minHeight = 0;
+    public int levels = 2;
+    public int levelHeight = 4;
+    public int height = levels * levelHeight;
+
+
+    public Building(OpenStreetMaps.Element element, Map<Long, OpenStreetMaps.Element> ways) {
+        this.element = element;
+        String tagBuilding = element.tags.get("building");
+        if (tagBuilding == null) throw new IllegalArgumentException("Building objects cannot be created from non-buildings. (No building tag)");
+
+        if (element.type == OpenStreetMaps.EType.way) {
+            Polygon polygon = new Polygon(element.geometry);
+            this.outerPolygons = new Polygon[] { polygon };
+
+            if (element.tags.containsKey("building:levels")) {
+                try {
+                    levels = Integer.parseInt(element.tags.get("building:levels"));
+                    height = levels * levelHeight;
+                } catch (NumberFormatException ignored) {}
+            }
+            if (element.tags.containsKey("building:height")) {
+                try {
+                    height = Integer.parseInt(element.tags.get("building:height"));
+                    levelHeight = height / levels;
+                } catch (NumberFormatException ignored) {}
+            } else {
+                height = levels * levelHeight;
+            }
+            if (element.tags.containsKey("building:min_height")) {
+                try {
+                    minHeight = Integer.parseInt(element.tags.get("building:min_height"));
+                } catch (NumberFormatException ignored) {}
+            }
+
+        } else if (element.type == OpenStreetMaps.EType.relation) {
+            List<Polygon> outerPolygons = new ArrayList<>(element.members.length);
+            List<Polygon> innerPolygons = new ArrayList<>(element.members.length);
+
+            for (OpenStreetMaps.Member member : element.members) {
+                if (member.type != OpenStreetMaps.EType.way)
+                    continue;
+                if (!ways.containsKey(member.ref))
+                    continue;
+                OpenStreetMaps.Element way = ways.get(member.ref);
+                Polygon polygon = new Polygon(way.geometry);
+                String role = member.role;
+                if (role == null)
+                    role = "outer"; // If there's no role, then it's probably an outer edge.
+                if (role.equals("outer")) {
+                    outerPolygons.add(polygon);
+                } else if (role.equals("inner")) {
+                    innerPolygons.add(polygon);
+                }
+            }
+
+            this.outerPolygons = outerPolygons.toArray(new Polygon[0]);
+            this.innerPolygons = innerPolygons.toArray(new Polygon[0]);
+
+            if (element.tags.containsKey("building:levels")) {
+                try {
+                    levels = Integer.parseInt(element.tags.get("building:levels"));
+                } catch (NumberFormatException ignored) {}
+            }
+            if (element.tags.containsKey("building:height")) {
+                try {
+                    height = Integer.parseInt(element.tags.get("building:height"));
+                    levelHeight = height / levels;
+                } catch (NumberFormatException ignored) {}
+            } else {
+                height = levels * levelHeight;
+            }
+            if (element.tags.containsKey("building:min_height")) {
+                try {
+                    minHeight = Integer.parseInt(element.tags.get("building:min_height"));
+                } catch (NumberFormatException ignored) {}
+            }
+        } else {
+            throw new IllegalArgumentException("Building Object constructor requires either a way or relation element");
+        }
+
+
+    }
+
+    public boolean contains(int x, int z) {
+        boolean inside = false;
+        for (Polygon p : outerPolygons)
+            if (p.isInside(x, z))
+                inside = true;
+
+        if (this.innerPolygons != null)
+            for (Polygon p : innerPolygons)
+                if (p.isInside(x, z))
+                    inside = false;
+        return inside;
+    }
+
+    public Building projectFromGeo(GeographicProjection projection) {
+        if (projection == null)
+            throw new IllegalArgumentException("Projection cannot be null!");
+        for (Polygon p : outerPolygons)
+            p.projectFromGeo(projection);
+        if (this.innerPolygons != null)
+        for (Polygon p : innerPolygons)
+            p.projectFromGeo(projection);
+        return this;
+    }
+
+    public int minX() {
+        int min = Integer.MAX_VALUE;
+        for (Polygon p : outerPolygons) {
+            int minX = p.minX();
+            if (minX < min)
+                min = minX;
+        }
+        return min;
+    }
+    public int minZ() {
+        int min = Integer.MAX_VALUE;
+        for (Polygon p : outerPolygons) {
+            int minZ = p.minZ();
+            if (minZ < min)
+                min = minZ;
+        }
+        return min;
+    }
+    public int maxX() {
+        int max = Integer.MIN_VALUE;
+        for (Polygon p : outerPolygons) {
+            int maxX = p.maxX();
+            if (maxX > max)
+                max = maxX;
+        }
+        return max;
+    }
+    public int maxZ() {
+        int max = Integer.MIN_VALUE;
+        for (Polygon p : outerPolygons) {
+            int maxZ = p.maxZ();
+            if (maxZ > max)
+                max = maxZ;
+        }
+        return max;
+    }
+
+    public void calculateHeights(Heights heights, GeographicProjection projection) {
+        double min = Double.MAX_VALUE;
+        double max = Double.MIN_VALUE;
+        for (int i = 0; i < outerPolygons.length; i++) {
+            Polygon p = outerPolygons[i];
+            for (OpenStreetMaps.Geometry g : p.vertices) {
+                double[] geo = projection.toGeo(g.lon, g.lat);
+                double height = heights.estimateLocal(geo[0], geo[1]);
+                if (height > max)
+                    max = height;
+                if (height < min)
+                    min = height;
+            }
+        }
+        this.heightOfLowestCorner = min;
+        this.heightOfHighestCorner = max;
+
+        this.hasCalculatedHeights = true;
+    }
+
+    @Override
+    public String toString() {
+        if (!element.tags.containsKey("name"))
+        return "Building{" +
+                "heightOfLowestCorner=" + heightOfLowestCorner +
+                ", heightOfHighestCorner=" + heightOfHighestCorner +
+                '}';
+        else
+            return "Building{" +
+                    "name = " + element.tags.get("name") +
+                    ", heightOfLowestCorner=" + heightOfLowestCorner +
+                    ", heightOfHighestCorner=" + heightOfHighestCorner +
+                    '}';
+    }
+}

--- a/src/main/java/io/github/terra121/dataset/OpenStreetMaps.java
+++ b/src/main/java/io/github/terra121/dataset/OpenStreetMaps.java
@@ -7,6 +7,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -33,17 +34,19 @@ public class OpenStreetMaps {
     private static final String OVERPASS_INSTANCE = "https://overpass-api.de";//"https://overpass.kumi.systems";
     private static final String URL_PREFACE = TerraConfig.serverOverpass + "/api/interpreter?data=[out:json];way(";
     private String URL_A = ")";
-    private static final String URL_B = ")%20tags%20qt;(._<;);out%20body%20qt;";
+    private static final String URL_B = "%20tags%20qt;(._<;);out%20body%20qt;";
     private static final String URL_C = "is_in(";
     private String URL_SUFFIX = ");area._[~\"natural|waterway\"~\"water|riverbank\"];out%20ids;";
 
     private HashMap<Coord, Set<Edge>> chunks;
+    private HashMap<Coord, Set<Building>> chunksBuildings;
     public LinkedHashMap<Coord, Region> regions;
     public Water water;
 
     private int numcache = TerraConfig.osmCacheSize;
 
     private ArrayList<Edge> allEdges;
+    private Set<Building> allBuildings;
 
     private Gson gson;
 
@@ -71,8 +74,10 @@ public class OpenStreetMaps {
 
     public OpenStreetMaps(GeographicProjection proj, boolean doRoad, boolean doWater, boolean doBuildings) {
         gson = new GsonBuilder().create();
-        chunks = new LinkedHashMap<Coord, Set<Edge>>();
+        chunks = new LinkedHashMap<>();
+        chunksBuildings = new LinkedHashMap<>();
         allEdges = new ArrayList<Edge>();
+        allBuildings = new HashSet<>();
         regions = new LinkedHashMap<Coord, Region>();
         projection = proj;
         try {
@@ -89,7 +94,7 @@ public class OpenStreetMaps {
         if (!doBuildings) URL_A += "[!\"building\"]";
         if (!doRoad) URL_A += "[!\"highway\"]";
         if (!doWater) URL_A += "[!\"water\"][!\"natural\"][!\"waterway\"]";
-        URL_A += ";out%20geom(";
+        URL_A += ";out%20geom";
     }
 
     public Coord getRegion(double lon, double lat) {
@@ -112,6 +117,24 @@ public class OpenStreetMaps {
             return null;
 
         return chunks.get(coord);
+    }
+
+    public Set<Building> chunkBuildings(int x, int z) {
+        Coord coord = new Coord(x, z);
+
+        if (regionCache(projection.toGeo(x * CHUNK_SIZE, z * CHUNK_SIZE)) == null)
+            return null;
+
+        if (regionCache(projection.toGeo((x + 1) * CHUNK_SIZE, z * CHUNK_SIZE)) == null)
+            return null;
+
+        if (regionCache(projection.toGeo((x + 1) * CHUNK_SIZE, (z + 1) * CHUNK_SIZE)) == null)
+            return null;
+
+        if (regionCache(projection.toGeo(x * CHUNK_SIZE, (z + 1) * CHUNK_SIZE)) == null)
+            return null;
+
+        return chunksBuildings.get(coord);
     }
 
     public Region regionCache(double[] corner) {
@@ -159,7 +182,7 @@ public class OpenStreetMaps {
             String bottomleft = Y + "," + X;
             String bbox = bottomleft + "," + (Y + TILE_SIZE) + "," + (X + TILE_SIZE);
 
-            String urltext = URL_PREFACE + bbox + URL_A + bbox + URL_B;
+            String urltext = URL_PREFACE + bbox + URL_A /*+ bbox */+ URL_B;
             if (doWater) urltext += URL_C + bottomleft + URL_SUFFIX;
 
             TerraMod.LOGGER.info(urltext);
@@ -194,6 +217,10 @@ public class OpenStreetMaps {
         for (Edge e : allEdges)
             relevantChunks(lowX, lowZ, highX, highZ, e);
         allEdges.clear();
+
+        for (Building b : allBuildings)
+            relevantChunks(b);
+        allBuildings.clear();
 
         return true;
     }
@@ -240,8 +267,10 @@ public class OpenStreetMaps {
 
                 if (naturalv != null && naturalv.equals("coastline")) {
                     waterway(elem, -1, region, null);
+                } else if (building != null) {
+                    allBuildings.add(new Building(elem, allWays).projectFromGeo(projection));
                 } else if (highway != null || (waterway != null && (waterway.equals("river") ||
-                        waterway.equals("canal") || waterway.equals("stream"))) || building != null) { //TODO: fewer equals
+                        waterway.equals("canal") || waterway.equals("stream")))) { //TODO: fewer equals
 
                     Type type = Type.ROAD;
 
@@ -251,8 +280,6 @@ public class OpenStreetMaps {
                             type = Type.RIVER;
 
                     }
-
-                    if (building != null) type = Type.BUILDING;
 
                     if (istunnel != null && istunnel.equals("yes")) {
 
@@ -366,16 +393,8 @@ public class OpenStreetMaps {
                         continue;
                     }
                 }
-                if(doBuildings && elem.tags.get("building")!=null) {
-                    for (Member member : elem.members) {
-                        if (member.type == EType.way) {
-                            Element way = allWays.get(member.ref);
-                            if (way != null) {
-                                addWay(way, Type.BUILDING, (byte) 1, region, Attributes.NONE, (byte) 0);
-                                unusedWays.remove(way);
-                            }
-                        }
-                    }
+                if(doBuildings && elem.tags.get("building") != null) {
+                    allBuildings.add(new Building(elem, allWays).projectFromGeo(projection));
                 }
 
             } else if (elem.type == EType.area) {
@@ -466,12 +485,28 @@ public class OpenStreetMaps {
         }
     }
 
-    private void assoiateWithChunk(Coord c, Edge edge) {
-        Set<Edge> list = chunks.get(c);
-        if (list == null) {
-            list = new HashSet<Edge>();
-            chunks.put(c, list);
+    private void relevantChunks(Building building) {
+        int lowX = (int)Math.floor(building.minX() / CHUNK_SIZE);
+        int lowZ = (int)Math.floor(building.minZ() / CHUNK_SIZE);
+        int highX = (int)Math.ceil(building.maxX() / CHUNK_SIZE);
+        int highZ = (int)Math.ceil(building.maxZ() / CHUNK_SIZE);
+//        System.out.println("relevantChunks(" + building + ") -> l: " + lowX + ", " + lowZ + "; h: " + highX + ", " + highZ);
+        // There's probably an error if this one building is relevant to 100+ chunks.
+//        if ((highX - lowX) * (highZ - lowZ) > 100) return;
+        for (int x = lowX; x < highX; x++) {
+            for (int z = lowZ; z < highZ; z++) {
+                assoiateWithChunk(new Coord(x, z), building);
+            }
         }
+    }
+
+    private void assoiateWithChunk(Coord c, Building building) {
+        Set<Building> list = chunksBuildings.computeIfAbsent(c, k -> new HashSet<Building>());
+        list.add(building);
+    }
+
+    private void assoiateWithChunk(Coord c, Edge edge) {
+        Set<Edge> list = chunks.computeIfAbsent(c, k -> new HashSet<Edge>());
         list.add(edge);
     }
 
@@ -599,20 +634,38 @@ public class OpenStreetMaps {
         EType type;
         long ref;
         String role;
+
+        Element element;
     }
 
     public static class Geometry {
-        double lat;
-        double lon;
+        public double lat;
+        public double lon;
+
+        public Geometry(){}
+
+        public Geometry(double lat, double lon) {
+            this.lat = lat;
+            this.lon = lon;
+        }
     }
 
     public static class Element {
-        EType type;
-        long id;
-        Map<String, String> tags;
-        long[] nodes;
-        Member[] members;
-        Geometry[] geometry;
+        public EType type;
+        public long id;
+        public Map<String, String> tags;
+        public long[] nodes;
+        public Member[] members;
+        public Geometry[] geometry;
+
+        @Override
+        public String toString() {
+            return type + "{" +
+                    "id=" + id +
+                    ", tags=" + tags +
+                    ", geometry=" + Arrays.toString(geometry) +
+                    '}';
+        }
     }
 
     public static class Data {

--- a/src/main/java/io/github/terra121/dataset/Polygon.java
+++ b/src/main/java/io/github/terra121/dataset/Polygon.java
@@ -1,0 +1,71 @@
+package io.github.terra121.dataset;
+
+import io.github.terra121.projection.GeographicProjection;
+
+public class Polygon {
+    public OpenStreetMaps.Geometry[] vertices;
+
+    public Polygon(OpenStreetMaps.Geometry[] vertices) {
+        this.vertices = vertices;
+        if (vertices.length < 3)
+            throw new IllegalArgumentException("Polygons cannot have fewer than 3 vertices.");
+    }
+
+    public boolean isInside(int x, int y) {
+        int j = vertices.length - 1;
+        boolean c = false;
+        for (int i = 0; i < vertices.length; i++) {
+            if (((vertices[i].lat > y) != (vertices[j].lat > y)) &&
+            (x < vertices[i].lon + (vertices[j].lon - vertices[i].lon) * (y - vertices[i].lat) /
+                    (vertices[j].lat - vertices[i].lat))) {
+                c = !c;
+            }
+            j = i;
+        }
+        return c;
+    }
+
+    public Polygon projectFromGeo(GeographicProjection projection) {
+        if (projection == null)
+            throw new IllegalArgumentException("Projection cannot be null!");
+        for (OpenStreetMaps.Geometry geom : vertices) {
+            double[] proj = projection.fromGeo(geom.lon, geom.lat);
+            geom.lon = proj[0];
+            geom.lat = proj[1];
+        }
+        return this;
+    }
+
+    public int minX() {
+        int min = Integer.MAX_VALUE;
+        for (OpenStreetMaps.Geometry g : vertices) {
+            if (g.lon < min)
+                min = (int)g.lon;
+        }
+        return min;
+    }
+    public int minZ() {
+        int min = Integer.MAX_VALUE;
+        for (OpenStreetMaps.Geometry g : vertices) {
+            if (g.lat < min)
+                min = (int)g.lat;
+        }
+        return min;
+    }
+    public int maxX() {
+        int max = Integer.MIN_VALUE;
+        for (OpenStreetMaps.Geometry g : vertices) {
+            if (g.lon > max)
+                max = (int)g.lon;
+        }
+        return max;
+    }
+    public int maxZ() {
+        int max = Integer.MIN_VALUE;
+        for (OpenStreetMaps.Geometry g : vertices) {
+            if (g.lat > max)
+                max = (int)g.lat;
+        }
+        return max;
+    }
+}

--- a/src/main/java/io/github/terra121/populator/BuildingGenerator.java
+++ b/src/main/java/io/github/terra121/populator/BuildingGenerator.java
@@ -21,8 +21,8 @@ import java.util.Random;
 import java.util.Set;
 
 public class BuildingGenerator implements ICubicStructureGenerator {
-    private static final IBlockState FOUNDATION = Blocks.CONCRETE.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.SILVER);
-    private static final IBlockState WALLS = Blocks.BRICK_BLOCK.getDefaultState();
+    public static final IBlockState FOUNDATION = Blocks.CONCRETE.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.SILVER);
+    public static final IBlockState WALLS = Blocks.BRICK_BLOCK.getDefaultState();
 
     private OpenStreetMaps osm;
     private Heights heights;
@@ -63,7 +63,7 @@ public class BuildingGenerator implements ICubicStructureGenerator {
                     if (building.contains(x, z)) {
                         if (minY >= chunkPosition.getMinBlockY())
                             cubePrimer.setBlockState(x - chunkPosition.getMinBlockX(), minY - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ(), FOUNDATION);
-                        for (int y = Math.max(minY, chunkPosition.getMinBlockY()); y <= Math.min(maxY+3, chunkPosition.getMaxBlockY()); y++)
+                        for (int y = Math.max(minY + 1, chunkPosition.getMinBlockY()); y <= Math.min(maxY+3, chunkPosition.getMaxBlockY()); y++)
                             if (cubePrimer.getBlockState(x - chunkPosition.getMinBlockX(), y - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ()) != WALLS)
                                 cubePrimer.setBlockState(x - chunkPosition.getMinBlockX(), y - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ(), Blocks.AIR.getDefaultState());
                     }

--- a/src/main/java/io/github/terra121/populator/BuildingGenerator.java
+++ b/src/main/java/io/github/terra121/populator/BuildingGenerator.java
@@ -1,0 +1,176 @@
+package io.github.terra121.populator;
+
+import io.github.opencubicchunks.cubicchunks.api.util.CubePos;
+import io.github.opencubicchunks.cubicchunks.api.worldgen.populator.ICubicPopulator;
+import io.github.terra121.dataset.Building;
+import io.github.terra121.dataset.Heights;
+import io.github.terra121.dataset.OpenStreetMaps;
+import io.github.terra121.dataset.Polygon;
+import io.github.terra121.projection.GeographicProjection;
+import net.minecraft.block.BlockColored;
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.EnumDyeColor;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.Biome;
+
+import java.util.Random;
+import java.util.Set;
+
+public class BuildingGenerator implements ICubicPopulator {
+    private static final IBlockState FOUNDATION = Blocks.CONCRETE.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.SILVER);
+    private static final IBlockState WALLS = Blocks.BRICK_BLOCK.getDefaultState();
+
+    private OpenStreetMaps osm;
+    private Heights heights;
+    private GeographicProjection projection;
+
+    public BuildingGenerator(OpenStreetMaps osm, Heights heights, GeographicProjection projection) {
+        this.osm = osm;
+        this.heights = heights;
+        this.projection = projection;
+    }
+
+    public void generate(World world, Random random, CubePos chunkPosition, Biome biome) {
+        Set<Building> buildings = osm.chunkBuildings(chunkPosition.getX(), chunkPosition.getZ());
+        world.setBlockState(chunkPosition.getMinBlockPos(), Blocks.WOOL.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.RED));
+        if (buildings != null)
+        for (Building building : buildings) {
+            if (!building.hasCalculatedHeights)
+                building.calculateHeights(heights, projection);
+            int minX = building.minX();
+            int minZ = building.minZ();
+            int maxX = building.maxX();
+            int maxZ = building.maxZ();
+            int minY;
+            int maxY;
+            if (building.minHeight != 0) {
+                world.setBlockState(chunkPosition.getMinBlockPos(), Blocks.WOOL.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.BLUE));
+                minY = (int)building.heightOfLowestCorner + building.minHeight;
+                maxY = minY + (building.height - building.minHeight);
+            } else {
+                world.setBlockState(chunkPosition.getMinBlockPos(), Blocks.WOOL.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.GREEN));
+                minY = (int) building.heightOfLowestCorner;
+                maxY = (int) Math.max(building.heightOfHighestCorner, minY + building.height);
+            }
+            if (maxY < chunkPosition.getMinBlockY() - 1) continue;
+            if (minY > chunkPosition.getMaxBlockY() + 1) continue;
+            world.setBlockState(chunkPosition.getMinBlockPos(), Blocks.WOOL.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.ORANGE));
+
+            // Foundation and set air above
+            for (int x = Math.max(minX, chunkPosition.getMinBlockX()); x <= Math.min(maxX, chunkPosition.getMaxBlockX()); x++) {
+                for (int z = Math.max(minZ, chunkPosition.getMinBlockZ()); z <= Math.min(maxZ, chunkPosition.getMaxBlockZ()); z++) {
+                    if (building.contains(x, z)) {
+                        world.setBlockState(new BlockPos(x, minY, z), FOUNDATION);
+                        for (int y = Math.max(minY, chunkPosition.getMinBlockY()); y <= maxY+3; y++)
+                            if (world.getBlockState(new BlockPos(x, y, z)) != WALLS)
+                                world.setBlockState(new BlockPos(x, y, z), Blocks.AIR.getDefaultState());
+                    }
+                }
+            }
+
+            // Walls
+            for (int y = Math.max(minY, chunkPosition.getMinBlockY()); y <= maxY; y++) {
+                for (Polygon p : building.outerPolygons) {
+                    OpenStreetMaps.Geometry last = p.vertices[0];
+                    for (int i = 1; i < p.vertices.length; i++) {
+                        OpenStreetMaps.Geometry current = p.vertices[i];
+                        placeLine(world, (int)last.lon, y, (int)last.lat, (int)current.lon, y, (int)current.lat, WALLS, chunkPosition);
+                        last = current;
+                    }
+                }
+                if (building.innerPolygons != null)
+                for (Polygon p : building.innerPolygons) {
+                    OpenStreetMaps.Geometry last = p.vertices[0];
+                    for (int i = 1; i < p.vertices.length; i++) {
+                        OpenStreetMaps.Geometry current = p.vertices[i];
+                        placeLine(world, (int)last.lon, y, (int)last.lat, (int)current.lon, y, (int)current.lat, WALLS, chunkPosition);
+                        last = current;
+                    }
+                }
+            }
+        }
+    }
+
+    private void placeLine(World world, int x0, int y0, int z0, int x1, int y1, int z1, IBlockState block, CubePos cube) {
+        int dx = Math.abs(x1 - x0);
+        int dy = Math.abs(y1 - y0);
+        int dz = Math.abs(z1 - z0);
+        int stepX = x0 < x1 ? 1 : -1;
+        int stepY = y0 < y1 ? 1 : -1;
+        int stepZ = z0 < z1 ? 1 : -1;
+        double hypotenuse = Math.sqrt(Math.pow(dx, 2) + Math.pow(dy, 2) + Math.pow(dz, 2));
+        double tMaxX = hypotenuse*0.5 / dx;
+        double tMaxY = hypotenuse*0.5 / dy;
+        double tMaxZ = hypotenuse*0.5 / dz;
+        double tDeltaX = hypotenuse / dx;
+        double tDeltaY = hypotenuse / dy;
+        double tDeltaZ = hypotenuse / dz;
+        while (x0 != x1 || y0 != y1 || z0 != z1){
+            if (tMaxX < tMaxY) {
+                if (tMaxX < tMaxZ) {
+                    x0 = x0 + stepX;
+                    tMaxX = tMaxX + tDeltaX;
+                }
+                else if (tMaxX > tMaxZ){
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+                }
+                else{
+                    x0 = x0 + stepX;
+                    tMaxX = tMaxX + tDeltaX;
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+                }
+            }
+            else if (tMaxX > tMaxY){
+                if (tMaxY < tMaxZ) {
+                    y0 = y0 + stepY;
+                    tMaxY = tMaxY + tDeltaY;
+                }
+                else if (tMaxY > tMaxZ){
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+                }
+                else{
+                    y0 = y0 + stepY;
+                    tMaxY = tMaxY + tDeltaY;
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+
+                }
+            }
+            else{
+                if (tMaxY < tMaxZ) {
+                    y0 = y0 + stepY;
+                    tMaxY = tMaxY + tDeltaY;
+                    x0 = x0 + stepX;
+                    tMaxX = tMaxX + tDeltaX;
+                }
+                else if (tMaxY > tMaxZ){
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+                }
+                else{
+                    x0 = x0 + stepX;
+                    tMaxX = tMaxX + tDeltaX;
+                    y0 = y0 + stepY;
+                    tMaxY = tMaxY + tDeltaY;
+                    z0 = z0 + stepZ;
+                    tMaxZ = tMaxZ + tDeltaZ;
+
+                }
+            }
+            if (
+                    x0 >= cube.getMinBlockX() &&
+                    x0 <= cube.getMaxBlockX() &&
+                    y0 >= cube.getMinBlockY() &&
+                    y0 <= cube.getMaxBlockY() &&
+                    z0 >= cube.getMinBlockZ() &&
+                    z0 <= cube.getMaxBlockZ()
+            )
+                world.setBlockState(new BlockPos(x0, y0, z0), block);
+        }
+    }
+}

--- a/src/main/java/io/github/terra121/populator/BuildingGenerator.java
+++ b/src/main/java/io/github/terra121/populator/BuildingGenerator.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 public class BuildingGenerator implements ICubicStructureGenerator {
     public static final IBlockState FOUNDATION = Blocks.CONCRETE.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.SILVER);
+    public static final IBlockState ROOF = Blocks.CONCRETE.getDefaultState().withProperty(BlockColored.COLOR, EnumDyeColor.BLACK);
     public static final IBlockState WALLS = Blocks.BRICK_BLOCK.getDefaultState();
 
     private OpenStreetMaps osm;
@@ -57,20 +58,25 @@ public class BuildingGenerator implements ICubicStructureGenerator {
             if (maxY < chunkPosition.getMinBlockY()) continue;
             if (minY > chunkPosition.getMaxBlockY()) continue;
 
-            // Foundation and set air above
+            // Foundation, roof, and clear area of building
             for (int x = Math.max(minX, chunkPosition.getMinBlockX()); x <= Math.min(maxX, chunkPosition.getMaxBlockX()); x++) {
                 for (int z = Math.max(minZ, chunkPosition.getMinBlockZ()); z <= Math.min(maxZ, chunkPosition.getMaxBlockZ()); z++) {
                     if (building.contains(x, z)) {
+                        // Foundation
                         if (minY >= chunkPosition.getMinBlockY())
                             cubePrimer.setBlockState(x - chunkPosition.getMinBlockX(), minY - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ(), FOUNDATION);
+                        // Air
                         for (int y = Math.max(minY + 1, chunkPosition.getMinBlockY()); y <= Math.min(maxY+3, chunkPosition.getMaxBlockY()); y++)
                             if (cubePrimer.getBlockState(x - chunkPosition.getMinBlockX(), y - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ()) != WALLS)
                                 cubePrimer.setBlockState(x - chunkPosition.getMinBlockX(), y - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ(), Blocks.AIR.getDefaultState());
+                            // Roof
+                        if (maxY-1 <= chunkPosition.getMaxBlockY())
+                            cubePrimer.setBlockState(x - chunkPosition.getMinBlockX(), maxY-1 - chunkPosition.getMinBlockY(), z - chunkPosition.getMinBlockZ(), ROOF);
                     }
                 }
             }
 
-            // Walls
+            // Walls (done afterward so it overwrites the edge of the roof)
             for (int y = Math.max(minY, chunkPosition.getMinBlockY()); y <= Math.min(maxY, chunkPosition.getMaxBlockY()); y++) {
                 for (Polygon p : building.outerPolygons) {
                     OpenStreetMaps.Geometry last = p.vertices[0];

--- a/src/main/java/io/github/terra121/populator/RoadGenerator.java
+++ b/src/main/java/io/github/terra121/populator/RoadGenerator.java
@@ -193,7 +193,12 @@ public class RoadGenerator implements ICubicPopulator {
 		
 		                    //clear the above blocks (to a point, we don't want to be here all day)
 		                    IBlockState defState = Blocks.AIR.getDefaultState();
-		                    for (int ay = y + 1; ay < 16 * 2 && world.getBlockState(new BlockPos(x + cubeX * 16, ay + cubeY * 16, z + cubeZ * 16)) != defState; ay++) {
+		                    for (int ay = y + 1; ay < 16 * 2 &&
+                                    (
+                                            world.getBlockState(new BlockPos(x + cubeX * 16, ay + cubeY * 16, z + cubeZ * 16)) != defState &&
+                                            world.getBlockState(new BlockPos(x + cubeX * 16, ay + cubeY * 16, z + cubeZ * 16)) != BuildingGenerator.WALLS &&
+                                            world.getBlockState(new BlockPos(x + cubeX * 16, ay + cubeY * 16, z + cubeZ * 16)) != BuildingGenerator.FOUNDATION
+                                    ); ay++) {
 		                        world.setBlockState(new BlockPos(x + cubeX * 16, ay + cubeY * 16, z + cubeZ * 16), defState);
 		                    }
                         }

--- a/src/main/resources/assets/terra121/lang/de_de.lang
+++ b/src/main/resources/assets/terra121/lang/de_de.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Strassen Generieren
 terra121.gui.smoothblend=glattes Mischen
 terra121.gui.dynamicbaseheight=Erzgenerierung auf Höhe basieren
 terra121.gui.osmwater=fortgeschrittenes Wassergenerierung (experimentell)
-terra121.gui.buildings=Gebäudegliederungen von OSM
+terra121.gui.buildings=Gebäude von OSM
 
 ## Projection types
 terra121.projection.web_mercator=Mercator

--- a/src/main/resources/assets/terra121/lang/en_us.lang
+++ b/src/main/resources/assets/terra121/lang/en_us.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Spawn Roads
 terra121.gui.smoothblend=Smooth Blending
 terra121.gui.dynamicbaseheight=Elevation Based Ores
 terra121.gui.osmwater=Advanced Water (experimental)
-terra121.gui.buildings=OSM Building Outlines
+terra121.gui.buildings=OSM Building Shells
 
 terra121.gui.biomemap=Debug Map
 

--- a/src/main/resources/assets/terra121/lang/es_es.lang
+++ b/src/main/resources/assets/terra121/lang/es_es.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Crear Calles
 terra121.gui.smoothblend=Suavizado
 terra121.gui.dynamicbaseheight=Altura de Minerales Dinámica
 terra121.gui.osmwater=Agua Avanzada (experimental)
-terra121.gui.buildings=Guías de Construcciones
+terra121.gui.buildings=Edificios de OSM
 
 ## Projection types
 terra121.projection.web_mercator=Mercator

--- a/src/main/resources/assets/terra121/lang/pl_pl.lang
+++ b/src/main/resources/assets/terra121/lang/pl_pl.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Drogi
 terra121.gui.smoothblend=Wygładzanie terenu
 terra121.gui.dynamicbaseheight=Wypiętrzone rudy
 terra121.gui.osmwater=Wody śródlądowe (eksperymentalne)
-terra121.gui.buildings=Krawędzie budynków z OSM
+terra121.gui.buildings=Budynków z OSM
 
 ## Projection types
 terra121.projection.web_mercator=Merkatora

--- a/src/main/resources/assets/terra121/lang/ru_ru.lang
+++ b/src/main/resources/assets/terra121/lang/ru_ru.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Создать дороги
 terra121.gui.smoothblend=Гладкое смешивание
 terra121.gui.dynamicbaseheight=Высота руды
 terra121.gui.osmwater=Продвинутая вода (экспериментально)
-terra121.gui.buildings=Контуры здания OSM
+terra121.gui.buildings=Здания OSM
 
 ## Projection types
 terra121.projection.web_mercator=Меркатор

--- a/src/main/resources/assets/terra121/lang/uk_uk.lang
+++ b/src/main/resources/assets/terra121/lang/uk_uk.lang
@@ -10,7 +10,7 @@ terra121.gui.roads=Створити дороги
 terra121.gui.smoothblend=Гладке змішування
 terra121.gui.dynamicbaseheight=Висота руди
 terra121.gui.osmwater=Просунута вода (експериментально)
-terra121.gui.buildings=Контури будівлі OSM
+terra121.gui.buildings=Будинки OSM
 
 ## Projection types
 terra121.projection.web_mercator=Меркатора

--- a/src/main/resources/assets/terra121/lang/zh_cn.lang
+++ b/src/main/resources/assets/terra121/lang/zh_cn.lang
@@ -20,7 +20,7 @@ terra121.gui.dynamicbaseheight=高海拔生成矿物
 
 terra121.gui.osmwater=高级水面（实验性）
 
-terra121.gui.buildings=OSM建筑轮廓
+terra121.gui.buildings=OSM建筑物
 
 
 


### PR DESCRIPTION
### What does it do?
This pull request adds more advanced buildings to Terra 1 to 1. Instead of lumping the edges of buildings in with all the rest of the edges, it creates Building objects based around polygons created from ways and multipolygon relations. The buildings are still organized by chunks. I also wrote a separate ICubicStructureGenerator because with some buildings being very tall, a populator does not work as it only runs on chunks at the surface.

### Screenshots
A random shopping center in Nashville, TN
![image](https://user-images.githubusercontent.com/23508878/80929757-15d19180-8d74-11ea-9b65-8b822cbcc4d7.png)
![image](https://user-images.githubusercontent.com/23508878/80929781-53361f00-8d74-11ea-9e6a-3affd51e89a3.png)

An area in downtown Nashville, TN
![image](https://user-images.githubusercontent.com/23508878/80929772-3d285e80-8d74-11ea-8511-9621e762690f.png)
![image](https://user-images.githubusercontent.com/23508878/80929766-2c77e880-8d74-11ea-8c32-828c3fcd182a.png)

### Change Log (major stuff)
- Added a new ICubicStructureGenerator class BuildingGenerator
- Added new Building and Polygon classes that represent the data of a building in the dataset package
- Added a couple methods to the OpenStreetMaps class to sort out the buildings from the rest
- Slightly modified RoadGenerator to avoid roads overwriting buildings

### Referenced Issues
#43 #28 

### Additional Notes
- This system for multipolygons may be useful for the advanced water you've been working on since that's how most water is represented in OSM.