### PR TITLE
Allowing parsing of degree symbol

### DIFF
--- a/src/main/java/io/github/terra121/control/TerraTeleport.java
+++ b/src/main/java/io/github/terra121/control/TerraTeleport.java
@@ -64,8 +64,14 @@ public class TerraTeleport extends CommandBase {
 			}
 			if(args[0].endsWith(","))
 				args[0] = args[0].substring(0, args[0].length() - 1);
-			if(args.length>1&&args[1].endsWith(","))
-				args[1] = args[1].substring(0, args[1].length() - 1);
+			if(args[0].endsWith("\u00B0"))
+				args[0] = args[0].substring(0, args[0].length() - 1);
+			if(args.length>1) {
+				if(args[1].endsWith(","))
+					args[1] = args[1].substring(0, args[1].length() - 1);
+				if(args[1].endsWith("\u00B0"))
+					args[1] = args[1].substring(0, args[1].length() - 1);
+			}
 			if(args.length!=2&&args.length!=3) {
 				throw new WrongUsageException(getUsage(sender), new Object[0]);
 			}


### PR DESCRIPTION
Added code that parses coordinates, even when there is a degree symbol at the end of the number. This is the format that some platforms, such as Google Earth, output.